### PR TITLE
Add log hint with test page URL

### DIFF
--- a/src/main/java/org/joinfaces/example/JarExampleApplication.java
+++ b/src/main/java/org/joinfaces/example/JarExampleApplication.java
@@ -11,5 +11,12 @@ public class JarExampleApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(JarExampleApplication.class, args);
+        
+        // Hint: with the default setup no welcome-page is configured,
+        // so opening the root path "/" results in a 404 error
+        // The URL has to include the page name as well, even for index.xhtml
+        Logger.getLogger(TestPrimefacesApplication.class.toString()).
+                info("Example page available at http://localhost:8080/index.xhtml");
+
     }
 }


### PR DESCRIPTION
Starting the test application with

```
git clone https://github.com/joinfaces/joinfaces-gradle-jar-example
cd joinfaces-gradle-jar-example
./gradlew bootRun
```

brings up a tomcat on port 8080, but opening http://localhost:8080 results in a 404. Same is true when started from an IDE.

This can make the user think the application is broken.

This PR adds a short log statement hinting at the working URL: http://localhost:8080/index.xhtml